### PR TITLE
New domain

### DIFF
--- a/domain-list.json
+++ b/domain-list.json
@@ -735,6 +735,7 @@
     "dlscordnltro.co.uk",
     "dlscordnltro.com",
     "dlscordnltro.ru",
+    "dlsordnltros.com",
     "dlscordrglft.xyz",
     "dlscords-glft.com",
     "dlscords.shop",


### PR DESCRIPTION
This domain does not work anymore because it redirects to the discord.com webpage, BUT it could be active soon again, so I am adding it here.