### PR TITLE
Remove discord[.]gift

### DIFF
--- a/domain-list.json
+++ b/domain-list.json
@@ -339,7 +339,6 @@
     "discord.events",
     "discord.foundation",
     "discord.fun",
-    "discord.gift",
     "discord.givaeway.com",
     "discord.givaewey.com",
     "discord.giveawey.com",


### PR DESCRIPTION
This domain just redirects to `discord[.]com`, and appears to be owned by Discord