### PR TITLE
Add dlscord-new-year.ru.com

### DIFF
--- a/domain-list.json
+++ b/domain-list.json
@@ -2245,6 +2245,7 @@
         "dlscord-link.com",
         "dlscord-main.ru.com",
         "dlscord-new.com",
+        "dlscord-new-year.ru.com",
         "dlscord-newyear.com",
         "dlscord-nitro.click",
         "dlscord-nitro.club",


### PR DESCRIPTION
Just had an attack over on my server with this domain name, and I had this repository open on my browser, so might as well add it here. The website seems to return 502 on `/`, but the following link was used in the phishing attempt:

```
dlscord-new-year.ru.com/gw20HkJ5qmqG13
```