### PR TITLE
added new domain to list

### DIFF
--- a/domain-list.json
+++ b/domain-list.json
@@ -3265,6 +3265,7 @@
     "nitrotypehack.club",
     "nitrowithsteam.com",
     "nltro-code.xyz",
+    "nltro-gift.ru.com",
     "nltro.com",
     "nltro.site",
     "nltroclassic.com",


### PR DESCRIPTION
added "nltro-gift.ru.com" to the list, the same domain with an i instead of a l already exists

I attached a screenshot of that domain in use for scamming
![pull_request](https://user-images.githubusercontent.com/98492671/151249208-cc1d8794-09a5-4f99-acde-e9d392baba7a.PNG)
.