### PR TITLE
New Domain :p

### DIFF
--- a/domain-list.json
+++ b/domain-list.json
@@ -4613,6 +4613,7 @@
     "joinmoderator.com",
     "joinmoderatoracademy.com",
     "joinmoderators.com",
+    "joinmy.site/join.php?id=ZQJ8RE",
     "joinrfor-teamhypesquad.com",
     "joins-the-hypesquadevents-news.com",
     "joint-moderator.com",


### PR DESCRIPTION
I recently found another phishing link that is to scam people by making them think they get free Discord Nitro.

- [x] Yes, I have checked both the domain-list.json and suspicious-list.json files, it is not there.
- [x] Yes this is a Discord-related scam.
- [x] Yes, it is in alphabetical order.

Proof:
![](https://capy-cdn.xyz/nHxgqKG3.png)
**A log showing the link that has been deleted by one of the moderators**