### PR TITLE
Added a domain: dsxcordglft.xyz

### DIFF
--- a/domain-list.json
+++ b/domain-list.json
@@ -12404,6 +12404,7 @@
     "xyzdlscorld.gift",
     "yanlima1120.repl.co",
     "yummy-nitro.com",
-    "ziscord-wwk.xyz"
+    "ziscord-wwk.xyz",
+    "dsxcordglft.xyz"
   ]
 }


### PR DESCRIPTION
Just got DM'd dsxcordglft.xyz/gift/0i8hY5IGtKZPlCnh and it redirects to dsxcordglft.xyz/login which is a fake mobile login site. dsxcordglft.xyz redirects to discord.com.