### PR TITLE
Add suspicious link

### DIFF
--- a/suspicious-list.json
+++ b/suspicious-list.json
@@ -12,6 +12,7 @@
     "546cd327-cyber-lan.site",
     "7dgw.com",
     "99box.com",
+    "rustroullette.com",
     "abardon.net.ru",
     "accept2.repl.co",
     "accgen.best",


### PR DESCRIPTION
This link seems to be your generic csgo/rust cases scam. 
https://prnt.sc/VBIFl6WCciL5